### PR TITLE
fix(php7.1) Fix iconv UTF-8 conversion Notice

### DIFF
--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -11,7 +11,8 @@ RUN apk add --no-cache --virtual .build-deps \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev libmcrypt-dev && \
     apk add --no-cache \
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
+        --repository http://dl-3.alpinelinux.org/alpine/edge/testing \
+        # --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
         --allow-untrusted \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium \


### PR DESCRIPTION
See https://github.com/phpearth/docker-php/issues/3 for further details.

You can reproduce/test by running `php -a` inside the `php-fpm` container and then executing the following function:
```
iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', 'šěýčíéáýřčíšýíščř');
```

before the fix, the following Notice will pop:
```
Notice: iconv(): Wrong charset, conversion from `UTF-8' to `ASCII//TRANSLIT//IGNORE' is not allowed in php shell code on line 1
```

after the fix, **no output** will be printed.
