### PR TITLE
feature(Docker): add support to Xdebug php extension in PHP 7.1

### DIFF
--- a/.github/workflows/dockerhub-publish.yml
+++ b/.github/workflows/dockerhub-publish.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ['5.6', '7.1', '7.2', '7.2-xdebug', '7.3', '7.4', '7.4-xdebug', '7.4-wk', '8.0', '8.0-xdebug', '8.0-prod']
+        image: ['5.6', '7.1', '7.1-xdebug', '7.2', '7.2-xdebug', '7.3', '7.4', '7.4-xdebug', '7.4-wk', '8.0', '8.0-xdebug', '8.0-prod']
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/7.1-xdebug/Dockerfile
+++ b/7.1-xdebug/Dockerfile
@@ -1,0 +1,44 @@
+FROM php:7.1-fpm-alpine
+
+WORKDIR /app
+
+ENV TZ=UTC
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
+
+RUN apk add --no-cache --virtual .build-deps \
+        $PHPIZE_DEPS curl-dev freetype-dev \
+        icu-dev imagemagick-dev libjpeg-turbo-dev \
+        libpng-dev libsodium-dev libtool \
+        libxml2-dev sqlite-dev libmcrypt-dev && \
+    apk add --no-cache \
+        --repository http://dl-3.alpinelinux.org/alpine/edge/testing \
+        --allow-untrusted \
+        bind-tools curl git gnu-libiconv \
+        imagemagick libsodium libgomp \
+        libintl libzip-dev \
+        icu shadow libmcrypt && \
+    pecl install imagick xdebug-2.5.0 && \
+    pecl install -o -f redis && \
+    pecl install -f libsodium && \
+    docker-php-ext-configure gd \
+        --with-jpeg-dir=/usr/lib \
+        --with-freetype-dir=/usr/include/freetype2 && \
+    docker-php-ext-enable imagick redis xdebug && \
+    docker-php-ext-install -j$(nproc) \
+        bcmath curl exif \
+        gd iconv intl mysqli \
+        pdo pdo_mysql pcntl \
+        soap tokenizer \
+        xml zip intl \
+        mcrypt mbstring && \
+    apk del -f .build-deps && \
+    cp "/usr/local/etc/php/php.ini-development" "/usr/local/etc/php/php.ini"
+
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
+RUN composer global require hirak/prestissimo
+
+COPY yampi.ini /usr/local/etc/php-fpm.d/zz-yampi.ini
+COPY www.conf /usr/local/etc/php-fpm.d/zz-www.conf
+COPY docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
+CMD ["php-fpm", "--allow-to-run-as-root", "--nodaemonize"]

--- a/7.1-xdebug/docker-php-ext-xdebug.ini
+++ b/7.1-xdebug/docker-php-ext-xdebug.ini
@@ -1,0 +1,7 @@
+xdebug.remote_enable=1
+xdebug.remote_handler=dbgp
+xdebug.remote_port=9000
+xdebug.remote_autostart=1
+xdebug.remote_connect_back=0
+xdebug.profiler_enable=0
+xdebug.remote_host=host.docker.internal

--- a/7.1-xdebug/www.conf
+++ b/7.1-xdebug/www.conf
@@ -1,0 +1,53 @@
+[www]
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+; Note: This value is mandatory.
+pm = dynamic
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 20
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+pm.start_servers = 10
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 5
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 10

--- a/7.1-xdebug/yampi.ini
+++ b/7.1-xdebug/yampi.ini
@@ -1,0 +1,15 @@
+[PHP]
+
+; Maximum amount of memory a script may consume
+; http://php.net/memory-limit
+memory_limit = 256M
+
+; Maximum allowed size for uploaded files.
+; http://php.net/upload-max-filesize
+upload_max_filesize = 10M
+
+; Maximum size of POST data that PHP will accept.
+; Its value may be 0 to disable the limit. It is ignored if POST data reading
+; is disabled through enable_post_data_reading.
+; http://php.net/post-max-size
+post_max_size = 10M


### PR DESCRIPTION
## Description

This changeset adds Xdebug ext. to PHP 7.1 image.

## Context and motivation

Help devs to debug code more efficiently.

## How was this tested?

Only Linux OS and Checkout project.

## Commands to execute when deploying

N/A
