### PR TITLE
feat(php8.1) Add PHP 8.1 base images + New workflow for branches other than master

### DIFF
--- a/.github/workflows/dockerhub-buildx-test.yml
+++ b/.github/workflows/dockerhub-buildx-test.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         image: ['5.6', '7.1', '7.1-xdebug', '7.2', '7.2-xdebug', '7.3', '7.4', '7.4-xdebug', '8.0', '8.0-xdebug', '8.0-prod', '8.1', '8.1-xdebug', '8.1-prod']
+        platforms: ['linux/amd64', 'linux/arm64']
     steps:
       -
         name: Set up QEMU
@@ -22,7 +23,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: "{{defaultContext}}:${{ matrix.image }}"
-          platforms: linux/amd64,linux/arm64
+          platforms: "${{ matrix.platforms }}"
           load: true
           tags: somosyampi/docker-php-fpm:${{ matrix.image }}-test
       -

--- a/.github/workflows/dockerhub-buildx-test.yml
+++ b/.github/workflows/dockerhub-buildx-test.yml
@@ -1,4 +1,4 @@
-name: Publish Docker multiplatform image
+name: Build and test Docker multiplatform images
 on:
   push:
     branches:

--- a/.github/workflows/dockerhub-buildx-test.yml
+++ b/.github/workflows/dockerhub-buildx-test.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         image: ['5.6', '7.1', '7.1-xdebug', '7.2', '7.2-xdebug', '7.3', '7.4', '7.4-xdebug', '8.0', '8.0-xdebug', '8.0-prod', '8.1', '8.1-xdebug', '8.1-prod']
+        platform: ['linux/amd64', 'linux/arm64']
     steps:
       -
         name: Set up QEMU
@@ -22,9 +23,11 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: "{{defaultContext}}:${{ matrix.image }}"
-          platforms: linux/amd64,linux/arm64
+          platforms: "${{ matrix.platform }}"
+          load: true
           tags: somosyampi/docker-php-fpm:${{ matrix.image }}-test
       -
         name: Test image
         run: |
+          docker image inspect somosyampi/docker-php-fpm:${{ matrix.image }}-test
           docker run --rm somosyampi/docker-php-fpm:${{ matrix.image }}-test php -i

--- a/.github/workflows/dockerhub-buildx-test.yml
+++ b/.github/workflows/dockerhub-buildx-test.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         image: ['5.6', '7.1', '7.1-xdebug', '7.2', '7.2-xdebug', '7.3', '7.4', '7.4-xdebug', '8.0', '8.0-xdebug', '8.0-prod', '8.1', '8.1-xdebug', '8.1-prod']
-        platforms: ['linux/amd64', 'linux/arm64']
     steps:
       -
         name: Set up QEMU
@@ -23,8 +22,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: "{{defaultContext}}:${{ matrix.image }}"
-          platforms: "${{ matrix.platforms }}"
-          load: true
+          platforms: linux/amd64,linux/arm64
           tags: somosyampi/docker-php-fpm:${{ matrix.image }}-test
       -
         name: Test image

--- a/.github/workflows/dockerhub-buildx-test.yml
+++ b/.github/workflows/dockerhub-buildx-test.yml
@@ -1,0 +1,31 @@
+name: Publish Docker multiplatform image
+on:
+  push:
+    branches:
+      - '**'
+      - '!master'
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: ['5.6', '7.1', '7.1-xdebug', '7.2', '7.2-xdebug', '7.3', '7.4', '7.4-xdebug', '8.0', '8.0-xdebug', '8.0-prod', '8.1', '8.1-xdebug', '8.1-prod']
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build image
+        uses: docker/build-push-action@v2
+        with:
+          context: "{{defaultContext}}:${{ matrix.image }}"
+          platforms: linux/amd64,linux/arm64
+          load: true
+          tags: somosyampi/docker-php-fpm:${{ matrix.image }}-test
+      -
+        name: Test image
+        run: |
+          docker run --rm somosyampi/docker-php-fpm:${{ matrix.image }}-test php -i

--- a/.github/workflows/dockerhub-publish-buildx.yml
+++ b/.github/workflows/dockerhub-publish-buildx.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ['5.6', '7.1', '7.1-xdebug', '7.2', '7.2-xdebug', '7.3', '7.4', '7.4-xdebug', '8.0', '8.0-xdebug', '8.0-prod']
+        image: ['5.6', '7.1', '7.1-xdebug', '7.2', '7.2-xdebug', '7.3', '7.4', '7.4-xdebug', '8.0', '8.0-xdebug', '8.0-prod', '8.1', '8.1-xdebug', '8.1-prod']
     steps:
       -
         name: Set up QEMU
@@ -18,7 +18,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}

--- a/8.1-prod/Dockerfile
+++ b/8.1-prod/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-fpm-alpine3.13
+FROM php:8.1-fpm-alpine
 
 WORKDIR /app
 
@@ -14,8 +14,6 @@ RUN apk add --no-cache --virtual .build-deps \
         imagemagick libsodium libgomp \
         libintl libzip-dev \
         icu shadow && \
-    pecl install imagick  && \
-    pecl install mongodb && \
     pecl install -o -f redis && \
     pecl install -f libsodium && \
     git clone \
@@ -24,22 +22,23 @@ RUN apk add --no-cache --virtual .build-deps \
     docker-php-ext-configure gd \
         --with-jpeg=/usr/lib \
         --with-freetype=/usr/include/freetype2 && \
-    docker-php-ext-enable imagick redis && \
-    docker-php-ext-enable mongodb && \
+    docker-php-ext-configure opcache --enable-opcache &&\
     docker-php-ext-install -j$(nproc) \
         bcmath curl exif \
-        gd iconv intl mysqli \
+        gd intl mysqli \
         pdo pdo_mysql pcntl \
-        soap tokenizer \
-        xml zip imagick sodium && \
+        soap opcache xml \
+        zip imagick sodium && \
+    docker-php-ext-enable imagick redis && \
     apk del -f .build-deps && \
     docker-php-source delete && \
     rm -rf /tmp/* /var/cache/apk/* && \
-    cp "/usr/local/etc/php/php.ini-development" "/usr/local/etc/php/php.ini"
+    cp "/usr/local/etc/php/php.ini-production" "/usr/local/etc/php/php.ini"
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 COPY yampi.ini /usr/local/etc/php-fpm.d/zz-yampi.ini
 COPY www.conf /usr/local/etc/php-fpm.d/zz-www.conf
+COPY opcache.ini /usr/local/etc/php/conf.d/05-opcache-recommended.ini
 
 CMD ["php-fpm", "--allow-to-run-as-root", "--nodaemonize"]

--- a/8.1-prod/opcache.ini
+++ b/8.1-prod/opcache.ini
@@ -1,0 +1,6 @@
+opcache.memory_consumption=128
+opcache.interned_strings_buffer=8
+opcache.max_accelerated_files=4000
+opcache.revalidate_freq=60
+opcache.fast_shutdown=1
+opcache.enable_cli=1

--- a/8.1-prod/www.conf
+++ b/8.1-prod/www.conf
@@ -1,0 +1,53 @@
+[www]
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+; Note: This value is mandatory.
+pm = dynamic
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 20
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+pm.start_servers = 10
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 5
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 10

--- a/8.1-prod/yampi.ini
+++ b/8.1-prod/yampi.ini
@@ -1,0 +1,15 @@
+[PHP]
+
+; Maximum amount of memory a script may consume
+; http://php.net/memory-limit
+memory_limit = 256M
+
+; Maximum allowed size for uploaded files.
+; http://php.net/upload-max-filesize
+upload_max_filesize = 10M
+
+; Maximum size of POST data that PHP will accept.
+; Its value may be 0 to disable the limit. It is ignored if POST data reading
+; is disabled through enable_post_data_reading.
+; http://php.net/post-max-size
+post_max_size = 10M

--- a/8.1-xdebug/Dockerfile
+++ b/8.1-xdebug/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-fpm-alpine3.13
+FROM php:8.1-fpm-alpine
 
 WORKDIR /app
 
@@ -14,8 +14,7 @@ RUN apk add --no-cache --virtual .build-deps \
         imagemagick libsodium libgomp \
         libintl libzip-dev \
         icu shadow && \
-    pecl install imagick  && \
-    pecl install mongodb && \
+    pecl install xdebug && \
     pecl install -o -f redis && \
     pecl install -f libsodium && \
     git clone \
@@ -24,22 +23,20 @@ RUN apk add --no-cache --virtual .build-deps \
     docker-php-ext-configure gd \
         --with-jpeg=/usr/lib \
         --with-freetype=/usr/include/freetype2 && \
-    docker-php-ext-enable imagick redis && \
-    docker-php-ext-enable mongodb && \
     docker-php-ext-install -j$(nproc) \
         bcmath curl exif \
-        gd iconv intl mysqli \
+        gd intl mysqli \
         pdo pdo_mysql pcntl \
-        soap tokenizer \
-        xml zip imagick sodium && \
+        soap xml zip \
+        imagick sodium && \
+    docker-php-ext-enable imagick redis xdebug && \
     apk del -f .build-deps && \
-    docker-php-source delete && \
-    rm -rf /tmp/* /var/cache/apk/* && \
     cp "/usr/local/etc/php/php.ini-development" "/usr/local/etc/php/php.ini"
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 COPY yampi.ini /usr/local/etc/php-fpm.d/zz-yampi.ini
 COPY www.conf /usr/local/etc/php-fpm.d/zz-www.conf
+COPY docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 CMD ["php-fpm", "--allow-to-run-as-root", "--nodaemonize"]

--- a/8.1-xdebug/docker-php-ext-xdebug.ini
+++ b/8.1-xdebug/docker-php-ext-xdebug.ini
@@ -1,0 +1,5 @@
+zend_extension=xdebug
+xdebug.mode=debug
+xdebug.start_with_request=yes
+xdebug.client_port=9000
+xdebug.client_host=host.docker.internal

--- a/8.1-xdebug/www.conf
+++ b/8.1-xdebug/www.conf
@@ -1,0 +1,53 @@
+[www]
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+; Note: This value is mandatory.
+pm = dynamic
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 20
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+pm.start_servers = 10
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 5
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 10

--- a/8.1-xdebug/yampi.ini
+++ b/8.1-xdebug/yampi.ini
@@ -1,0 +1,15 @@
+[PHP]
+
+; Maximum amount of memory a script may consume
+; http://php.net/memory-limit
+memory_limit = 256M
+
+; Maximum allowed size for uploaded files.
+; http://php.net/upload-max-filesize
+upload_max_filesize = 10M
+
+; Maximum size of POST data that PHP will accept.
+; Its value may be 0 to disable the limit. It is ignored if POST data reading
+; is disabled through enable_post_data_reading.
+; http://php.net/post-max-size
+post_max_size = 10M

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-fpm-alpine3.13
+FROM php:8.1-fpm-alpine
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ RUN apk add --no-cache --virtual .build-deps \
         imagemagick libsodium libgomp \
         libintl libzip-dev \
         icu shadow && \
-    pecl install imagick  && \
+    pecl install imagick && \
     pecl install mongodb && \
     pecl install -o -f redis && \
     pecl install -f libsodium && \
@@ -28,10 +28,10 @@ RUN apk add --no-cache --virtual .build-deps \
     docker-php-ext-enable mongodb && \
     docker-php-ext-install -j$(nproc) \
         bcmath curl exif \
-        gd iconv intl mysqli \
+        gd intl mysqli \
         pdo pdo_mysql pcntl \
-        soap tokenizer \
-        xml zip imagick sodium && \
+        soap xml zip \
+        imagick sodium && \
     apk del -f .build-deps && \
     docker-php-source delete && \
     rm -rf /tmp/* /var/cache/apk/* && \

--- a/8.1/www.conf
+++ b/8.1/www.conf
@@ -1,0 +1,53 @@
+[www]
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+; Note: This value is mandatory.
+pm = dynamic
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 20
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+pm.start_servers = 10
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 5
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 10

--- a/8.1/yampi.ini
+++ b/8.1/yampi.ini
@@ -1,0 +1,16 @@
+[PHP]
+
+; Maximum amount of memory a script may consume
+; http://php.net/memory-limit
+memory_limit = 256M
+
+; Maximum allowed size for uploaded files.
+; http://php.net/upload-max-filesize
+upload_max_filesize = 10M
+
+; Maximum size of POST data that PHP will accept.
+; Its value may be 0 to disable the limit. It is ignored if POST data reading
+; is disabled through enable_post_data_reading.
+; http://php.net/post-max-size
+post_max_size = 10M
+extension = mongodb.so


### PR DESCRIPTION
## Description

This PR adds PHP 8.1 base images. It includes the development version, production and also dev + xdebug.

If you compare the 8.1 with 8.0 image, you'll see that besides the `FROM` image bump, I removed a few packages from the `docker-php-ext-install` command. `iconv` and `tokenizer` are already included in the php compile within those images, so we don't need to install them again. If we try to install, it will fail.

## Context and motivation

For PHP 8.1, will probably use it in the near future. No spoilers 👀 

For the new test workflow, the idea is to build / test images on branches other than master, so we know if they work before pushing to master.

## How was this tested?

Locally, you can run the following commands. It will build and then test the images, by inspecting them and running `php -i` in each of them. Or you can check the [Github Actions job](https://github.com/somosyampi/docker-php-fpm/actions/runs/3190684249) that ran successfully on the last commit.

Build

```sh
docker build -t somosyampi/docker-php-fpm:8.1 8.1
docker build -t somosyampi/docker-php-fpm:8.1-xdebug 8.1-xdebug
docker build -t somosyampi/docker-php-fpm:8.1-prod 8.1-prod
```

Test

```sh
docker image inspect somosyampi/docker-php-fpm:8.1
docker image inspect somosyampi/docker-php-fpm:8.1-xdebug
docker image inspect somosyampi/docker-php-fpm:8.1-prod

docker run --rm somosyampi/docker-php-fpm:8.1 php -i
docker run --rm somosyampi/docker-php-fpm:8.1-xdebug php -i
docker run --rm somosyampi/docker-php-fpm:8.1-prod php -i
```