### PR TITLE
refactor: Drop mongo, fix xdebug images, bump GA steps versions, add new vulnerability scan

### DIFF
--- a/.github/workflows/dockerhub-buildx-test.yml
+++ b/.github/workflows/dockerhub-buildx-test.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ['5.6', '7.1', '7.1-xdebug', '7.2', '7.2-xdebug', '7.3', '7.4', '7.4-xdebug', '8.0', '8.0-xdebug', '8.0-prod', '8.1', '8.1-xdebug', '8.1-prod']
-        platform: ['linux/amd64', 'linux/arm64']
+        image: ['8.0', '8.0-xdebug', '8.0-prod']
+        platform: ['linux/amd64']
     steps:
       -
         name: Set up QEMU

--- a/.github/workflows/dockerhub-buildx-test.yml
+++ b/.github/workflows/dockerhub-buildx-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ['8.0', '8.0-xdebug', '8.0-prod']
+        image: ['5.6', '7.1', '7.1-xdebug', '7.2', '7.2-xdebug', '7.3', '7.4', '7.4-xdebug', '8.0', '8.0-xdebug', '8.0-prod', '8.1', '8.1-xdebug', '8.1-prod']
         platform: ['linux/amd64']
     steps:
       -

--- a/.github/workflows/dockerhub-buildx-test.yml
+++ b/.github/workflows/dockerhub-buildx-test.yml
@@ -31,3 +31,9 @@ jobs:
         run: |
           docker image inspect somosyampi/docker-php-fpm:${{ matrix.image }}-test
           docker run --rm somosyampi/docker-php-fpm:${{ matrix.image }}-test php -i
+      -
+        name: Scan for vulnerabilities
+        uses: crazy-max/ghaction-container-scan@v2
+        with:
+          image: somosyampi/docker-php-fpm:${{ matrix.image }}-test
+          annotations: true

--- a/.github/workflows/dockerhub-buildx-test.yml
+++ b/.github/workflows/dockerhub-buildx-test.yml
@@ -13,6 +13,9 @@ jobs:
         platform: ['linux/amd64']
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       -
@@ -37,3 +40,4 @@ jobs:
         with:
           image: somosyampi/docker-php-fpm:${{ matrix.image }}-test
           annotations: true
+          dockerfile: ./${{ matrix.image }}/Dockerfile

--- a/.github/workflows/dockerhub-buildx-test.yml
+++ b/.github/workflows/dockerhub-buildx-test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         image: ['5.6', '7.1', '7.1-xdebug', '7.2', '7.2-xdebug', '7.3', '7.4', '7.4-xdebug', '8.0', '8.0-xdebug', '8.0-prod', '8.1', '8.1-xdebug', '8.1-prod']
-        platform: ['linux/amd64']
+        platform: ['linux/amd64', 'linux/arm64']
     steps:
       -
         name: Checkout

--- a/.github/workflows/dockerhub-buildx-test.yml
+++ b/.github/workflows/dockerhub-buildx-test.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Build image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: "{{defaultContext}}:${{ matrix.image }}"
           platforms: "${{ matrix.platform }}"

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -10,10 +10,10 @@ jobs:
   docker-description:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Update Docker Hub Description
-        uses: peter-evans/dockerhub-description@v2
+        uses: peter-evans/dockerhub-description@v3
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/dockerhub-publish-buildx.yml
+++ b/.github/workflows/dockerhub-publish-buildx.yml
@@ -12,19 +12,19 @@ jobs:
     steps:
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: "{{defaultContext}}:${{ matrix.image }}"
           platforms: linux/amd64,linux/arm64

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -7,7 +7,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone &
     apt-get update && apt-get install -y gnupg zip unzip git && mkdir -p ~/.gnupg && \
     echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" > /etc/apt/sources.list.d/ppa_ondrej_php.list && \
     apt-key adv --homedir ~/.gnupg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E5267A6C && \
-    apt-get update && apt-get install -y \
+    apt-get update && apt-get upgrade -y && apt-get install -y \
         php5.6-fpm php5.6-cli php5.6-mcrypt \
         php5.6-sqlite3 php5.6-gd \
         php5.6-curl php5.6-imap php5.6-mysql \

--- a/7.1-xdebug/Dockerfile
+++ b/7.1-xdebug/Dockerfile
@@ -5,12 +5,13 @@ WORKDIR /app
 ENV TZ=UTC
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev libmcrypt-dev && \
-    apk add --no-cache \
+    apk add --no-cache --update \
         --repository http://dl-3.alpinelinux.org/alpine/edge/testing \
         --allow-untrusted \
         bind-tools curl git gnu-libiconv \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -5,12 +5,13 @@ WORKDIR /app
 ENV TZ=UTC
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev libmcrypt-dev && \
-    apk add --no-cache \
+    apk add --no-cache --update  \
         --repository http://dl-3.alpinelinux.org/alpine/edge/testing \
         # --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
         --allow-untrusted \

--- a/7.2-xdebug/Dockerfile
+++ b/7.2-xdebug/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache --virtual .build-deps \
         imagemagick libsodium libgomp \
         libintl libzip-dev \
         icu shadow && \
-    pecl install imagick xdebug && \
+    pecl install imagick xdebug-3.1.6 && \
     pecl install -o -f redis && \
     pecl install -f libsodium && \
     docker-php-ext-configure gd \

--- a/7.2-xdebug/Dockerfile
+++ b/7.2-xdebug/Dockerfile
@@ -14,13 +14,13 @@ RUN apk add --no-cache --virtual .build-deps \
         imagemagick libsodium libgomp \
         libintl libzip-dev \
         icu shadow && \
-    pecl install imagick mongodb xdebug && \
+    pecl install imagick xdebug && \
     pecl install -o -f redis && \
     pecl install -f libsodium && \
     docker-php-ext-configure gd \
         --with-jpeg-dir=/usr/lib \
         --with-freetype-dir=/usr/include/freetype2 && \
-    docker-php-ext-enable imagick mongodb redis xdebug && \
+    docker-php-ext-enable imagick redis xdebug && \
     docker-php-ext-install -j$(nproc) \
         bcmath curl exif \
         gd iconv intl mysqli \

--- a/7.2-xdebug/Dockerfile
+++ b/7.2-xdebug/Dockerfile
@@ -4,12 +4,13 @@ WORKDIR /app
 
 ENV TZ=UTC
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
-    apk add --no-cache \
+    apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
         libintl libzip-dev \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -14,13 +14,13 @@ RUN apk add --no-cache --virtual .build-deps \
         imagemagick libsodium libgomp \
         libintl libzip-dev \
         icu shadow && \
-    pecl install imagick mongodb && \
+    pecl install imagick && \
     pecl install -o -f redis && \
     pecl install -f libsodium && \
     docker-php-ext-configure gd \
         --with-jpeg-dir=/usr/lib \
         --with-freetype-dir=/usr/include/freetype2 && \
-    docker-php-ext-enable imagick mongodb redis && \
+    docker-php-ext-enable imagick redis && \
     docker-php-ext-install -j$(nproc) \
         bcmath curl exif \
         gd iconv intl mysqli \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -4,12 +4,13 @@ WORKDIR /app
 
 ENV TZ=UTC
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
-    apk add --no-cache \
+    apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
         libintl libzip-dev \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -4,12 +4,13 @@ WORKDIR /app
 
 ENV TZ=UTC
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
-    apk add --no-cache \
+    apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
         libintl libzip-dev \

--- a/7.4-xdebug/Dockerfile
+++ b/7.4-xdebug/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache --virtual .build-deps \
         imagemagick libsodium libgomp \
         libintl libzip-dev \
         icu shadow && \
-    pecl install imagick xdebug && \
+    pecl install imagick xdebug-3.1.6 && \
     pecl install -o -f redis && \
     pecl install -f libsodium && \
     docker-php-ext-configure gd \

--- a/7.4-xdebug/Dockerfile
+++ b/7.4-xdebug/Dockerfile
@@ -14,13 +14,13 @@ RUN apk add --no-cache --virtual .build-deps \
         imagemagick libsodium libgomp \
         libintl libzip-dev \
         icu shadow && \
-    pecl install imagick mongodb xdebug && \
+    pecl install imagick xdebug && \
     pecl install -o -f redis && \
     pecl install -f libsodium && \
     docker-php-ext-configure gd \
         --with-jpeg=/usr/lib \
         --with-freetype=/usr/include/freetype2 && \
-    docker-php-ext-enable imagick mongodb redis xdebug && \
+    docker-php-ext-enable imagick redis xdebug && \
     docker-php-ext-install -j$(nproc) \
         bcmath curl exif \
         gd iconv intl mysqli \

--- a/7.4-xdebug/Dockerfile
+++ b/7.4-xdebug/Dockerfile
@@ -4,12 +4,13 @@ WORKDIR /app
 
 ENV TZ=UTC
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
-    apk add --no-cache \
+    apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
         libintl libzip-dev \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -14,13 +14,13 @@ RUN apk add --no-cache --virtual .build-deps \
         imagemagick libsodium libgomp \
         libintl libzip-dev \
         icu shadow && \
-    pecl install imagick mongodb && \
+    pecl install imagick && \
     pecl install -o -f redis && \
     pecl install -f libsodium && \
     docker-php-ext-configure gd \
         --with-jpeg=/usr/lib \
         --with-freetype=/usr/include/freetype2 && \
-    docker-php-ext-enable imagick mongodb redis && \
+    docker-php-ext-enable imagick redis && \
     docker-php-ext-install -j$(nproc) \
         bcmath curl exif \
         gd iconv intl mysqli \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -4,12 +4,13 @@ WORKDIR /app
 
 ENV TZ=UTC
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
-    apk add --no-cache \
+    apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
         libintl libzip-dev \

--- a/8.0-prod/Dockerfile
+++ b/8.0-prod/Dockerfile
@@ -4,12 +4,13 @@ WORKDIR /app
 
 ENV TZ=UTC
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
-    apk add --no-cache \
+    apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
         libintl libzip-dev \

--- a/8.0-xdebug/Dockerfile
+++ b/8.0-xdebug/Dockerfile
@@ -4,12 +4,13 @@ WORKDIR /app
 
 ENV TZ=UTC
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS linux-headers curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
-    apk add --no-cache \
+    apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
         libintl libzip-dev \

--- a/8.0-xdebug/Dockerfile
+++ b/8.0-xdebug/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 ENV TZ=UTC
 
 RUN apk add --no-cache --virtual .build-deps \
-        $PHPIZE_DEPS curl-dev freetype-dev \
+        $PHPIZE_DEPS linux-headers curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -15,7 +15,6 @@ RUN apk add --no-cache --virtual .build-deps \
         libintl libzip-dev \
         icu shadow && \
     pecl install imagick  && \
-    pecl install mongodb && \
     pecl install -o -f redis && \
     pecl install -f libsodium && \
     git clone \
@@ -25,7 +24,6 @@ RUN apk add --no-cache --virtual .build-deps \
         --with-jpeg=/usr/lib \
         --with-freetype=/usr/include/freetype2 && \
     docker-php-ext-enable imagick redis && \
-    docker-php-ext-enable mongodb && \
     docker-php-ext-install -j$(nproc) \
         bcmath curl exif \
         gd iconv intl mysqli \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -4,12 +4,13 @@ WORKDIR /app
 
 ENV TZ=UTC
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
-    apk add --no-cache \
+    apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
         libintl libzip-dev \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 ENV TZ=UTC
 
 RUN apk upgrade --no-cache && \
-    apk add --no-cache --virtual .build-deps \
+    apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
@@ -15,7 +15,7 @@ RUN apk upgrade --no-cache && \
         imagemagick libsodium libgomp \
         libintl libzip-dev \
         icu shadow && \
-    pecl install imagick  && \
+    pecl install imagick && \
     pecl install -o -f redis && \
     pecl install -f libsodium && \
     git clone \

--- a/8.0/yampi.ini
+++ b/8.0/yampi.ini
@@ -13,4 +13,3 @@ upload_max_filesize = 10M
 ; is disabled through enable_post_data_reading.
 ; http://php.net/post-max-size
 post_max_size = 10M
-extension = mongodb.so

--- a/8.1-prod/Dockerfile
+++ b/8.1-prod/Dockerfile
@@ -4,12 +4,13 @@ WORKDIR /app
 
 ENV TZ=UTC
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
-    apk add --no-cache \
+    apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
         libintl libzip-dev \

--- a/8.1-xdebug/Dockerfile
+++ b/8.1-xdebug/Dockerfile
@@ -4,12 +4,13 @@ WORKDIR /app
 
 ENV TZ=UTC
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS linux-headers curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
-    apk add --no-cache \
+    apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
         libintl libzip-dev \

--- a/8.1-xdebug/Dockerfile
+++ b/8.1-xdebug/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 ENV TZ=UTC
 
 RUN apk add --no-cache --virtual .build-deps \
-        $PHPIZE_DEPS curl-dev freetype-dev \
+        $PHPIZE_DEPS linux-headers curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -15,7 +15,6 @@ RUN apk add --no-cache --virtual .build-deps \
         libintl libzip-dev \
         icu shadow && \
     pecl install imagick && \
-    pecl install mongodb && \
     pecl install -o -f redis && \
     pecl install -f libsodium && \
     git clone \
@@ -25,7 +24,6 @@ RUN apk add --no-cache --virtual .build-deps \
         --with-jpeg=/usr/lib \
         --with-freetype=/usr/include/freetype2 && \
     docker-php-ext-enable imagick redis && \
-    docker-php-ext-enable mongodb && \
     docker-php-ext-install -j$(nproc) \
         bcmath curl exif \
         gd intl mysqli \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -4,12 +4,13 @@ WORKDIR /app
 
 ENV TZ=UTC
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
-    apk add --no-cache \
+    apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
         libintl libzip-dev \

--- a/8.1/yampi.ini
+++ b/8.1/yampi.ini
@@ -13,4 +13,3 @@ upload_max_filesize = 10M
 ; is disabled through enable_post_data_reading.
 ; http://php.net/post-max-size
 post_max_size = 10M
-extension = mongodb.so


### PR DESCRIPTION
## Description

This PR refactors the images to fix / refactor / improve several things:

- Fix build error on some 7.x and 8.x xdebug images. This was discovered while working on the upcoming PHP 8.2 images. [See this failed build](https://github.com/somosyampi/docker-php-fpm/actions/runs/3658146125/jobs/6187067026). Adding `linux-headers` as a virtual dependency fixes the build issue.
- Drop mongo dependency since it was removed due to not being used anymore.
- Bump Github Actions steps versions to fix the Annotation warning spam (node 12 drop, `set-output` command is deprecated, etc). [See this action summary.](https://github.com/somosyampi/docker-php-fpm/actions/runs/3660539661)
- Add new Vulnerability Scan step to show us if any images we use are vulnerable to any attacks.
- Add update / upgrade commands to all images to fix most of the issues pointed by the new scan step.

**NOTE:** I was not able to fix all the vulnerabilities annotation due to the 5.6 image using an old Ubuntu version. We could try manually updating the deps described there, but since 5.6 is no longer supported and we plan on removing it sooner than later, I decided not to focusing on it.

## Context and motivation

I was working on the new php 8.2 images, but stumbled up onto the xdebug images build failing. Had to solve it first before I was able to move forward. 

The other ones are improvements I decided to work on while tackling the xdebug fail.

## How was this tested?

The commands executed locally to test this are the following:

```sh
export VERSION=5.6
docker build -t somosyampi/docker-php-fpm:$VERSION $VERSION --no-cache --pull
docker run -it --rm somosyampi/docker-php-fpm:$VERSION php -i
```

Change the `VERSION` value to test the different versions. Or, look at the Github Actions runs.
