### PR TITLE
feat(php8.2) Add PHP 8.2 images

### DIFF
--- a/.github/workflows/dockerhub-buildx-test.yml
+++ b/.github/workflows/dockerhub-buildx-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ['5.6', '7.1', '7.1-xdebug', '7.2', '7.2-xdebug', '7.3', '7.4', '7.4-xdebug', '8.0', '8.0-xdebug', '8.0-prod', '8.1', '8.1-xdebug', '8.1-prod']
+        image: ['5.6', '7.1', '7.1-xdebug', '7.2', '7.2-xdebug', '7.3', '7.4', '7.4-xdebug', '8.0', '8.0-xdebug', '8.0-prod', '8.1', '8.1-xdebug', '8.1-prod', '8.2', '8.2-xdebug', '8.2-prod']
         platform: ['linux/amd64', 'linux/arm64']
     steps:
       -

--- a/.github/workflows/dockerhub-publish-buildx.yml
+++ b/.github/workflows/dockerhub-publish-buildx.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ['5.6', '7.1', '7.1-xdebug', '7.2', '7.2-xdebug', '7.3', '7.4', '7.4-xdebug', '8.0', '8.0-xdebug', '8.0-prod', '8.1', '8.1-xdebug', '8.1-prod']
+        image: ['5.6', '7.1', '7.1-xdebug', '7.2', '7.2-xdebug', '7.3', '7.4', '7.4-xdebug', '8.0', '8.0-xdebug', '8.0-prod', '8.1', '8.1-xdebug', '8.1-prod', '8.2', '8.2-xdebug', '8.2-prod']
     steps:
       -
         name: Set up QEMU

--- a/8.2-prod/Dockerfile
+++ b/8.2-prod/Dockerfile
@@ -1,0 +1,44 @@
+FROM php:8.2-fpm-alpine
+
+WORKDIR /app
+
+ENV TZ=UTC
+
+RUN apk add --no-cache --virtual .build-deps \
+        $PHPIZE_DEPS curl-dev freetype-dev \
+        icu-dev imagemagick-dev libjpeg-turbo-dev \
+        libpng-dev libsodium-dev libtool \
+        libxml2-dev sqlite-dev && \
+    apk add --no-cache \
+        bind-tools curl git gnu-libiconv \
+        imagemagick libsodium libgomp \
+        libintl libzip-dev \
+        icu shadow && \
+    pecl install -o -f redis && \
+    pecl install -f libsodium && \
+    git clone \
+            https://github.com/Imagick/imagick.git \
+            /usr/src/php/ext/imagick && \
+    docker-php-ext-configure gd \
+        --with-jpeg=/usr/lib \
+        --with-freetype=/usr/include/freetype2 && \
+    docker-php-ext-configure opcache --enable-opcache &&\
+    docker-php-ext-install -j$(nproc) \
+        bcmath curl exif \
+        gd intl mysqli \
+        pdo pdo_mysql pcntl \
+        soap opcache xml \
+        zip imagick sodium && \
+    docker-php-ext-enable imagick redis && \
+    apk del -f .build-deps && \
+    docker-php-source delete && \
+    rm -rf /tmp/* /var/cache/apk/* && \
+    cp "/usr/local/etc/php/php.ini-production" "/usr/local/etc/php/php.ini"
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+
+COPY yampi.ini /usr/local/etc/php-fpm.d/zz-yampi.ini
+COPY www.conf /usr/local/etc/php-fpm.d/zz-www.conf
+COPY opcache.ini /usr/local/etc/php/conf.d/05-opcache-recommended.ini
+
+CMD ["php-fpm", "--allow-to-run-as-root", "--nodaemonize"]

--- a/8.2-prod/Dockerfile
+++ b/8.2-prod/Dockerfile
@@ -4,12 +4,13 @@ WORKDIR /app
 
 ENV TZ=UTC
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
-    apk add --no-cache \
+    apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
         libintl libzip-dev \

--- a/8.2-prod/opcache.ini
+++ b/8.2-prod/opcache.ini
@@ -1,0 +1,6 @@
+opcache.memory_consumption=128
+opcache.interned_strings_buffer=8
+opcache.max_accelerated_files=4000
+opcache.revalidate_freq=60
+opcache.fast_shutdown=1
+opcache.enable_cli=1

--- a/8.2-prod/www.conf
+++ b/8.2-prod/www.conf
@@ -1,0 +1,53 @@
+[www]
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+; Note: This value is mandatory.
+pm = dynamic
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 20
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+pm.start_servers = 10
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 5
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 10

--- a/8.2-prod/yampi.ini
+++ b/8.2-prod/yampi.ini
@@ -1,0 +1,15 @@
+[PHP]
+
+; Maximum amount of memory a script may consume
+; http://php.net/memory-limit
+memory_limit = 256M
+
+; Maximum allowed size for uploaded files.
+; http://php.net/upload-max-filesize
+upload_max_filesize = 10M
+
+; Maximum size of POST data that PHP will accept.
+; Its value may be 0 to disable the limit. It is ignored if POST data reading
+; is disabled through enable_post_data_reading.
+; http://php.net/post-max-size
+post_max_size = 10M

--- a/8.2-xdebug/Dockerfile
+++ b/8.2-xdebug/Dockerfile
@@ -4,15 +4,15 @@ WORKDIR /app
 
 ENV TZ=UTC
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
-        libxml2-dev sqlite-dev && \
-    apk add --no-cache \
-        bind-tools curl git gnu-libiconv \
-        imagemagick libsodium libgomp \
-        libintl libzip-dev \
+        libxml2-dev sqlite-dev linux-headers && \
+    apk add --no-cache --update \
+        bind-tools curl git \
+        gnu-libiconv imagemagick libsodium \
+        libgomp libintl libzip-dev \
         icu shadow && \
     pecl install xdebug && \
     pecl install -o -f redis && \

--- a/8.2-xdebug/Dockerfile
+++ b/8.2-xdebug/Dockerfile
@@ -1,0 +1,42 @@
+FROM php:8.2-fpm-alpine
+
+WORKDIR /app
+
+ENV TZ=UTC
+
+RUN apk add --no-cache --virtual .build-deps \
+        $PHPIZE_DEPS curl-dev freetype-dev \
+        icu-dev imagemagick-dev libjpeg-turbo-dev \
+        libpng-dev libsodium-dev libtool \
+        libxml2-dev sqlite-dev && \
+    apk add --no-cache \
+        bind-tools curl git gnu-libiconv \
+        imagemagick libsodium libgomp \
+        libintl libzip-dev \
+        icu shadow && \
+    pecl install xdebug && \
+    pecl install -o -f redis && \
+    pecl install -f libsodium && \
+    git clone \
+            https://github.com/Imagick/imagick.git \
+            /usr/src/php/ext/imagick && \
+    docker-php-ext-configure gd \
+        --with-jpeg=/usr/lib \
+        --with-freetype=/usr/include/freetype2 && \
+    docker-php-ext-install -j$(nproc) \
+        bcmath curl exif \
+        gd intl mysqli \
+        pdo pdo_mysql pcntl \
+        soap xml zip \
+        imagick sodium && \
+    docker-php-ext-enable imagick redis xdebug && \
+    apk del -f .build-deps && \
+    cp "/usr/local/etc/php/php.ini-development" "/usr/local/etc/php/php.ini"
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+
+COPY yampi.ini /usr/local/etc/php-fpm.d/zz-yampi.ini
+COPY www.conf /usr/local/etc/php-fpm.d/zz-www.conf
+COPY docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
+CMD ["php-fpm", "--allow-to-run-as-root", "--nodaemonize"]

--- a/8.2-xdebug/Dockerfile
+++ b/8.2-xdebug/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /app
 
 ENV TZ=UTC
 
-RUN apk add --no-cache --update --virtual .build-deps \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \

--- a/8.2-xdebug/docker-php-ext-xdebug.ini
+++ b/8.2-xdebug/docker-php-ext-xdebug.ini
@@ -1,0 +1,5 @@
+zend_extension=xdebug
+xdebug.mode=debug
+xdebug.start_with_request=yes
+xdebug.client_port=9000
+xdebug.client_host=host.docker.internal

--- a/8.2-xdebug/www.conf
+++ b/8.2-xdebug/www.conf
@@ -1,0 +1,53 @@
+[www]
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+; Note: This value is mandatory.
+pm = dynamic
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 20
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+pm.start_servers = 10
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 5
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 10

--- a/8.2-xdebug/yampi.ini
+++ b/8.2-xdebug/yampi.ini
@@ -1,0 +1,15 @@
+[PHP]
+
+; Maximum amount of memory a script may consume
+; http://php.net/memory-limit
+memory_limit = 256M
+
+; Maximum allowed size for uploaded files.
+; http://php.net/upload-max-filesize
+upload_max_filesize = 10M
+
+; Maximum size of POST data that PHP will accept.
+; Its value may be 0 to disable the limit. It is ignored if POST data reading
+; is disabled through enable_post_data_reading.
+; http://php.net/post-max-size
+post_max_size = 10M

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -1,0 +1,43 @@
+FROM php:8.2-fpm-alpine
+
+WORKDIR /app
+
+ENV TZ=UTC
+
+RUN apk add --no-cache --virtual .build-deps \
+        $PHPIZE_DEPS curl-dev freetype-dev \
+        icu-dev imagemagick-dev libjpeg-turbo-dev \
+        libpng-dev libsodium-dev libtool \
+        libxml2-dev sqlite-dev && \
+    apk add --no-cache \
+        bind-tools curl git gnu-libiconv \
+        imagemagick libsodium libgomp \
+        libintl libzip-dev \
+        icu shadow && \
+    pecl install imagick && \
+    pecl install -o -f redis && \
+    pecl install -f libsodium && \
+    git clone \
+            https://github.com/Imagick/imagick.git \
+            /usr/src/php/ext/imagick && \
+    docker-php-ext-configure gd \
+        --with-jpeg=/usr/lib \
+        --with-freetype=/usr/include/freetype2 && \
+    docker-php-ext-enable imagick redis && \
+    docker-php-ext-install -j$(nproc) \
+        bcmath curl exif \
+        gd intl mysqli \
+        pdo pdo_mysql pcntl \
+        soap xml zip \
+        imagick sodium && \
+    apk del -f .build-deps && \
+    docker-php-source delete && \
+    rm -rf /tmp/* /var/cache/apk/* && \
+    cp "/usr/local/etc/php/php.ini-development" "/usr/local/etc/php/php.ini"
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+
+COPY yampi.ini /usr/local/etc/php-fpm.d/zz-yampi.ini
+COPY www.conf /usr/local/etc/php-fpm.d/zz-www.conf
+
+CMD ["php-fpm", "--allow-to-run-as-root", "--nodaemonize"]

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -4,12 +4,13 @@ WORKDIR /app
 
 ENV TZ=UTC
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
         icu-dev imagemagick-dev libjpeg-turbo-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
-    apk add --no-cache \
+    apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
         libintl libzip-dev \

--- a/8.2/www.conf
+++ b/8.2/www.conf
@@ -1,0 +1,53 @@
+[www]
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+; Note: This value is mandatory.
+pm = dynamic
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 20
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+pm.start_servers = 10
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 5
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 10

--- a/8.2/yampi.ini
+++ b/8.2/yampi.ini
@@ -1,0 +1,15 @@
+[PHP]
+
+; Maximum amount of memory a script may consume
+; http://php.net/memory-limit
+memory_limit = 256M
+
+; Maximum allowed size for uploaded files.
+; http://php.net/upload-max-filesize
+upload_max_filesize = 10M
+
+; Maximum size of POST data that PHP will accept.
+; Its value may be 0 to disable the limit. It is ignored if POST data reading
+; is disabled through enable_post_data_reading.
+; http://php.net/post-max-size
+post_max_size = 10M


### PR DESCRIPTION
## Description

This PR adds PHP 8.2 base images. It includes the development version, production and also dev + xdebug.

## Context and motivation

PHP 8.2 was released last month, and we might use in some services.

## How was this tested?

Locally, you can run the following commands. It will build and then test the images, by inspecting them and running `php -i` in each of them. Or you can check the [Github Actions job](https://github.com/somosyampi/docker-php-fpm/actions/runs/3688154868/jobs/6242627121) that ran successfully on the last commit.

Build

```sh
docker build -t somosyampi/docker-php-fpm:8.2 8.2
docker build -t somosyampi/docker-php-fpm:8.2-xdebug 8.2-xdebug
docker build -t somosyampi/docker-php-fpm:8.2-prod 8.2-prod
```

Test

```sh
docker image inspect somosyampi/docker-php-fpm:8.2
docker image inspect somosyampi/docker-php-fpm:8.2-xdebug
docker image inspect somosyampi/docker-php-fpm:8.2-prod

docker run --rm somosyampi/docker-php-fpm:8.2 php -i
docker run --rm somosyampi/docker-php-fpm:8.2-xdebug php -i
docker run --rm somosyampi/docker-php-fpm:8.2-prod php -i
```