### PR TITLE
fix: move libjpeg-turbo-dev to non-virtual install

### DIFF
--- a/8.1-prod/Dockerfile
+++ b/8.1-prod/Dockerfile
@@ -7,13 +7,13 @@ ENV TZ=UTC
 RUN apk upgrade --no-cache && \
     apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
-        icu-dev imagemagick-dev libjpeg-turbo-dev \
+        icu-dev imagemagick-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
     apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
-        libintl libzip-dev \
+        libintl libzip-dev libjpeg-turbo-dev \
         icu shadow && \
     pecl install -o -f redis && \
     git clone \

--- a/8.1-xdebug/Dockerfile
+++ b/8.1-xdebug/Dockerfile
@@ -7,13 +7,13 @@ ENV TZ=UTC
 RUN apk upgrade --no-cache && \
     apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS linux-headers curl-dev freetype-dev \
-        icu-dev imagemagick-dev libjpeg-turbo-dev \
+        icu-dev imagemagick-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
     apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
-        libintl libzip-dev \
+        libintl libzip-dev libjpeg-turbo-dev \
         icu shadow && \
     pecl install xdebug && \
     pecl install -o -f redis && \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -7,13 +7,13 @@ ENV TZ=UTC
 RUN apk upgrade --no-cache && \
     apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
-        icu-dev imagemagick-dev libjpeg-turbo-dev \
+        icu-dev imagemagick-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
     apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
-        libintl libzip-dev \
+        libintl libzip-dev libjpeg-turbo-dev \
         icu shadow && \
     pecl install imagick && \
     pecl install -o -f redis && \

--- a/8.2-prod/Dockerfile
+++ b/8.2-prod/Dockerfile
@@ -7,13 +7,13 @@ ENV TZ=UTC
 RUN apk upgrade --no-cache && \
     apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
-        icu-dev imagemagick-dev libjpeg-turbo-dev \
+        icu-dev imagemagick-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
     apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
-        libintl libzip-dev \
+        libintl libzip-dev libjpeg-turbo-dev \
         icu shadow && \
     pecl install -o -f redis && \
     git clone \

--- a/8.2-xdebug/Dockerfile
+++ b/8.2-xdebug/Dockerfile
@@ -7,13 +7,13 @@ ENV TZ=UTC
 RUN apk upgrade --no-cache && \
     apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
-        icu-dev imagemagick-dev libjpeg-turbo-dev \
+        icu-dev imagemagick-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev linux-headers && \
     apk add --no-cache --update \
         bind-tools curl git \
         gnu-libiconv imagemagick libsodium \
-        libgomp libintl libzip-dev \
+        libgomp libintl libzip-dev libjpeg-turbo-dev \
         icu shadow && \
     pecl install xdebug && \
     pecl install -o -f redis && \

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -7,13 +7,13 @@ ENV TZ=UTC
 RUN apk upgrade --no-cache && \
     apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
-        icu-dev imagemagick-dev libjpeg-turbo-dev \
+        icu-dev imagemagick-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
     apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
-        libintl libzip-dev \
+        libintl libzip-dev libjpeg-turbo-dev \
         icu shadow && \
     pecl install -o -f redis && \
     git clone \

--- a/8.3-prod/Dockerfile
+++ b/8.3-prod/Dockerfile
@@ -7,13 +7,13 @@ ENV TZ=UTC
 RUN apk upgrade --no-cache && \
     apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
-        icu-dev imagemagick-dev libjpeg-turbo-dev \
+        icu-dev imagemagick-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
     apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
-        libintl libzip-dev \
+        libintl libzip-dev libjpeg-turbo-dev \
         icu shadow && \
     pecl install -o -f redis && \
     git clone \

--- a/8.3-xdebug/Dockerfile
+++ b/8.3-xdebug/Dockerfile
@@ -7,13 +7,13 @@ ENV TZ=UTC
 RUN apk upgrade --no-cache && \
     apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
-        icu-dev imagemagick-dev libjpeg-turbo-dev \
+        icu-dev imagemagick-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev linux-headers && \
     apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
-        libintl libzip-dev \
+        libintl libzip-dev libjpeg-turbo-dev \
         icu shadow && \
     pecl install xdebug && \
     pecl install -o -f redis && \

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -7,13 +7,13 @@ ENV TZ=UTC
 RUN apk upgrade --no-cache && \
     apk add --no-cache --update --virtual .build-deps \
         $PHPIZE_DEPS curl-dev freetype-dev \
-        icu-dev imagemagick-dev libjpeg-turbo-dev \
+        icu-dev imagemagick-dev \
         libpng-dev libsodium-dev libtool \
         libxml2-dev sqlite-dev && \
     apk add --no-cache --update \
         bind-tools curl git gnu-libiconv \
         imagemagick libsodium libgomp \
-        libintl libzip-dev \
+        libintl libzip-dev libjpeg-turbo-dev \
         icu shadow && \
     pecl install -o -f redis && \
     git clone \
@@ -28,7 +28,7 @@ RUN apk upgrade --no-cache && \
         pdo pdo_mysql pcntl \
         soap xml zip \
         imagick sodium && \
-    docker-php-ext-enable imagick redis && \
+    docker-php-ext-enable imagick redis gd && \
     apk del -f .build-deps && \
     docker-php-source delete && \
     rm -rf /tmp/* /var/cache/apk/* && \


### PR DESCRIPTION
Esse PR corrige o erro de lib gd não conseguir carregar algumas libs do libjpeg, pois o pacote estava sendo removido por ser instalado de forma virtual.

https://github.com/somosyampi/docker-php-fpm/actions/runs/9085674955/job/24969565381#step:6:119