### PR TITLE
fix: pin protobuf version and scope GHA cache by platform

### DIFF
--- a/.github/workflows/template-build-test.yml
+++ b/.github/workflows/template-build-test.yml
@@ -36,8 +36,8 @@ jobs:
           build-args: "${{ inputs.build-args }}"
           load: true
           tags: somosyampi/docker-php-fpm:${{ inputs.image }}-test
-          cache-from: type=gha,scope=${{ inputs.image }}
-          cache-to: type=gha,mode=max,scope=${{ inputs.image }}
+          cache-from: type=gha,scope=${{ inputs.image }}-${{ inputs.platform }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.image }}-${{ inputs.platform }}
       -
         name: Test image
         run: |

--- a/.github/workflows/template-publish.yml
+++ b/.github/workflows/template-publish.yml
@@ -39,5 +39,5 @@ jobs:
           build-args: "${{ inputs.build-args }}"
           push: true
           tags: somosyampi/docker-php-fpm:${{ inputs.image }}
-          cache-from: type=gha,scope=${{ inputs.image }}
-          cache-to: type=gha,mode=max,scope=${{ inputs.image }}
+          cache-from: type=gha,scope=${{ inputs.image }}-${{ inputs.platform }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.image }}-${{ inputs.platform }}

--- a/8.3-xdebug/Dockerfile
+++ b/8.3-xdebug/Dockerfile
@@ -17,7 +17,7 @@ RUN apk upgrade --no-cache && \
         icu shadow gmp-dev && \
     pecl install xdebug && \
     pecl install -o -f redis && \
-    pecl install protobuf && \
+    pecl install protobuf-4.33.6 && \
     git clone \
             https://github.com/Imagick/imagick.git \
             /usr/src/php/ext/imagick && \

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -16,7 +16,7 @@ RUN apk upgrade --no-cache && \
         libintl libzip-dev libjpeg-turbo-dev \
         icu shadow gmp-dev && \
     pecl install -o -f redis && \
-    pecl install protobuf && \
+    pecl install protobuf-4.33.6 && \
     git clone \
             https://github.com/Imagick/imagick.git \
             /usr/src/php/ext/imagick && \


### PR DESCRIPTION
## Summary
- Pin protobuf PECL extension to version 4.33.6 in PHP 8.3 and 8.3-xdebug Dockerfiles
- Add platform to GHA cache scope in build-test and publish workflow templates to avoid cross-architecture cache collisions

## Test plan
- [ ] Verify CI builds pass for both amd64 and arm64
- [ ] Confirm cache is created with platform-specific scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)